### PR TITLE
Add space for egl-gbm pointer in surface struct

### DIFF
--- a/tegra_udrm_gbm_int.h
+++ b/tegra_udrm_gbm_int.h
@@ -25,6 +25,7 @@
 #define _GBM_TUDRM_INTERNAL_H_
 
 #include "gbmint.h"
+#include <stddef.h>
 
 #define ALIGN(val, align) (((val) + (align) - 1) & ~((align) - 1))
 
@@ -49,6 +50,7 @@ struct gbm_tudrm_bo {
 };
 
 struct gbm_tudrm_surface {
+   void *reserved_for_egl_gbm;
    struct gbm_surface base;
    struct gbm_surface *nvgbm_surface;
 };
@@ -68,7 +70,7 @@ gbm_tudrm_bo(struct gbm_bo *bo)
 static inline struct gbm_tudrm_surface *
 gbm_tudrm_surface(struct gbm_surface *surface)
 {
-   return (struct gbm_tudrm_surface *) surface;
+   return (struct gbm_tudrm_surface *)((char *)surface - offsetof(struct gbm_tudrm_surface, base));
 }
 
 #endif


### PR DESCRIPTION
egl-gbm expects to be able store a pointer just
in front of the gbm_surface struct for holding it
private data (see the SetPrivPtr and GetPrivPtr
functions in gbm-surface.c).  Since we're implementing
the create/destroy functions for gbm_surface, we
need to accommodate this in our wrapper structure.

This looks like it fixes the SIGABRT on initial startup issue I was seeing.